### PR TITLE
修復自帶數據集在網站頁面不顯示的問題

### DIFF
--- a/chapter_13/QASystem/bin/doc_to_redis.py
+++ b/chapter_13/QASystem/bin/doc_to_redis.py
@@ -1,16 +1,27 @@
 import pymongo
 import redis
 
-
-client = redis.Redis()
-db = pymongo.MongoClient().qa_system
+client = redis.Redis(password='appleyuchi',host='localhost', port=6379, db=0)
+db = pymongo.MongoClient('mongodb://adminUser:adminPass@127.0.0.1:27017').qa_system
 question = db.question
 answer = db.answer
 
-# for row in question.find({}, {'_id': 1}):
-#     _id = str(row['_id'])
-#     client.zadd('qa_system:question:vote', _id, 0)
+#----------------------------初始化问题数据集,写入redis-------------------------------------------------
+# 先注释并且运行第一个for循环,
+# {'_id': 1}表示mongodb查詢的結果中帶有_id
+for row in question.find({}, {'_id': 1,'vote_up':1,'vote_down':1}):
+    print("row=",row)
+    _id = str(row['_id'])
+    try:
+        client.zadd('qa_system:question:vote', {_id:row['vote_up']-row['vote_down']})#所有問題的點讚數都是零
+# 这里的_id指的是问题的value,0指的是点赞数(redis中的score)
+    except:
+    	client.zadd('qa_system:question:vote', {_id:0})#如果暫時沒有人對該問題點讚或者點踩，那麼點讚數設爲0
 
-for row in answer.find({}, {'_id': 1, 'question_id': 1}):
-    _id = row['_id']
-    client.zadd('qa_system:answer:{}:vote'.format(row['question_id']), _id, 0)
+#----------------------------初始化答案数据集,写入redis-------------------------------------------------
+for row in answer.find({}, {'_id': 1, 'question_id': 1,'vote_up':1,'vote_down':1}):
+    _id = str(row['_id'])
+    try:
+        client.zadd('qa_system:answer:{}:vote'.format(str(row['question_id'])), {_id:row['vote_up']-row['vote_down']})
+    except:
+        client.zadd('qa_system:answer:{}:vote'.format(str(row['question_id'])), {_id:0})

--- a/chapter_13/QASystem/generate_question.py
+++ b/chapter_13/QASystem/generate_question.py
@@ -1,15 +1,21 @@
 import pymongo
-
-
-handler = pymongo.MongoClient().qa_system.question
+from bson import ObjectId
+handler = pymongo.MongoClient('mongodb://adminUser:adminPass@127.0.0.1:27017').qa_system.question
 question = [
-    {'author': '王小一',
+
+# 下面這個修改完了(已經覈實)
+    {"_id" : ObjectId("5b8b8fb9d3a25054b7a0dc23"),
+    'author': '王小一',
      'title': '1+1=?',
      'detail': '请问1+1等于几？',
      'ask_time': '2018-07-23 12:18:11',
      'vote_up': 0,
      'vote_down': 100},
-    {'author': '张小二',
+
+
+# 下面這個修改完了(已經覈實)
+    {"_id":ObjectId("5b8b8fb9d3a25054b7a0dc24"),
+    'author': '张小二',
      'title': '为什么说42 is the answer of all?',
      'detail': '这句话出自哪里？',
      'ask_time': '2018-07-23 12:18:11',
@@ -21,25 +27,36 @@ question = [
      'ask_time': '2018-07-23 12:18:11',
      'vote_up': 10,
      'vote_down': 10},
-    {'author': '旺小四',
+
+
+# 下面這個修改完了(已經覈實)
+    {
+    "_id" : ObjectId("5b8b8fb9d3a25054b7a0dc26"),
+    'author': '旺小四',
      'title': '此时相忘不相闻下一句是什么?',
      'detail': '还有，这是谁写的诗？',
      'ask_time': '2018-07-23 12:18:11',
      'vote_up': 100,
      'vote_down': 3},
+
+
     {'author': '赵小五',
      'title': '把微波炉温度调低一些，可以孵鸡蛋吗？',
      'detail': '孵蛋除了温度还需要什么？',
      'ask_time': '2018-07-23 12:18:11',
      'vote_up': 23,
      'vote_down': 3},
+
     {'author': '朱小六',
      'title': '四大名著你喜欢哪一本？',
      'detail': '请回答具体原因。',
      'ask_time': '2018-07-23 12:18:11',
      'vote_up': 70,
      'vote_down': 2},
-    {'author': '马小七',
+
+    {
+    "_id" : ObjectId("5b8b8fb9d3a25054b7a0dc29"),
+    'author': '马小七',
      'title': '你知道明朝时期的四大名著，除了《西游记》《水浒传》和《三国演义》还有一本是什么吗？',
      'detail': '这本书的作者又是是呢？',
      'ask_time': '2018-07-23 12:18:11',


### PR DESCRIPTION
环境:
系统:ubuntu19.10
支持的redis-cli版本:5.0.5
python:3.6.10
mongo:3.6.8


修复的issue是:
https://github.com/kingname/SourceCodeofMongoRedis/issues/7

被修改的文件为:
bin/doc_to_redis.py(上传书本自带数据集的问题部分和答案部分)
generate_question.py


不显示点赞数量的原因:
doc_to_redis.py的上传部分的代码有问题,已经修复


不显示答案的原因:
generate_question.py导入question时,没有指定id,
但是generate_answer.py中的answer对应的question的id是固定的.
查询结果不匹配导致页面有问题,但是不显示答案.


修改后的效果:
![修改后效果](https://user-images.githubusercontent.com/27613483/79970772-01fd7400-84c6-11ea-92f9-d42354a75f63.png)


